### PR TITLE
change follow-redirect to 10 for fix eof error

### DIFF
--- a/lib/rest-firebase.rb
+++ b/lib/rest-firebase.rb
@@ -13,7 +13,7 @@ RestFirebase = RC::Builder.client(:d, :secret, :auth, :auth_ttl, :iat) do
 
   use RC::Retry         , 0, RC::Retry::DefaultRetryExceptions
   use RC::Timeout       , 10
-  use RC::FollowRedirect, 1
+  use RC::FollowRedirect, 10
   use RC::ErrorHandler  , lambda{ |env| RestFirebase::Error.call(env) }
   use RC::ErrorDetectorHttp
   use RC::JsonResponse  , true


### PR DESCRIPTION
Since 2015-11-14 12am(GMT), receive EOFError on event_source.

Firebase support team says,

> We indeed introduced an extra redirect in the initial setup of the connection from the client to the correct Firebase server.
> So I change follow-redirect to 10.

The issue is fixed.
